### PR TITLE
Respect db_prefix

### DIFF
--- a/Console/Command/CleanUpAttributesAndValuesWithoutParentCommand.php
+++ b/Console/Command/CleanUpAttributesAndValuesWithoutParentCommand.php
@@ -73,8 +73,8 @@ class CleanUpAttributesAndValuesWithoutParentCommand extends Command
                 ->getFirstItem();
             $output->writeln("<info>Cleaning values for $code</info>");
             foreach ($types as $type) {
-                $eavTable         = $db->getTableName('eav_attribute');
-                $entityValueTable = $db->getTableName($code . '_entity_' . $type);
+                $eavTable         = $this->resourceConnection->getTableName('eav_attribute');
+                $entityValueTable = $this->resourceConnection->getTableName($code . '_entity_' . $type);
                 $query            = "SELECT * FROM $entityValueTable WHERE `attribute_id` NOT IN(SELECT attribute_id"
                     . " FROM `$eavTable` WHERE entity_type_id = " . $entityType->getEntityTypeId() . ")";
                 $results          = $db->fetchAll($query);

--- a/Console/Command/RemoveUnusedAttributesCommand.php
+++ b/Console/Command/RemoveUnusedAttributesCommand.php
@@ -68,10 +68,10 @@ class RemoveUnusedAttributesCommand extends Command
         $attributes              = $this->attributeRepository
             ->getList(ProductAttributeInterface::ENTITY_TYPE_CODE, $searchCriteria)
             ->getItems();
-        $eavAttributeTable       = $db->getTableName('eav_attribute');
-        $eavEntityAttributeTable = $db->getTableName('eav_entity_attribute');
+        $eavAttributeTable       = $this->resourceConnection->getTableName('eav_attribute');
+        $eavEntityAttributeTable = $this->resourceConnection->getTableName('eav_entity_attribute');
         foreach ($attributes as $attribute) {
-            $table = $db->getTableName('catalog_product_entity_' . $attribute->getBackendType());
+            $table = $this->resourceConnection->getTableName('catalog_product_entity_' . $attribute->getBackendType());
             /* Look for attributes that have no values set in products */
             $attributeValues = (int)$db->fetchOne('SELECT COUNT(*) FROM ' . $table . ' WHERE attribute_id = ?',
                 [$attribute->getAttributeId()]);

--- a/Console/Command/RemoveUnusedMediaCommand.php
+++ b/Console/Command/RemoveUnusedMediaCommand.php
@@ -60,7 +60,7 @@ class RemoveUnusedMediaCommand extends Command
 
         $imageDir          = $this->getImageDir();
         $connection        = $this->resourceConnection->getConnection('core_read');
-        $mediaGalleryTable = $connection->getTableName('catalog_product_entity_media_gallery');
+        $mediaGalleryTable = $this->resourceConnection->getTableName('catalog_product_entity_media_gallery');
 
         $directoryIterator = new RecursiveDirectoryIterator($imageDir);
 

--- a/Console/Command/RestoreUseDefaultConfigValueCommand.php
+++ b/Console/Command/RestoreUseDefaultConfigValueCommand.php
@@ -46,18 +46,20 @@ class RestoreUseDefaultConfigValueCommand extends Command
         $removedConfigValues = 0;
 
         $db         = $this->resourceConnection->getConnection();
-        $configData = $db->fetchAll('SELECT DISTINCT path, value FROM ' . $db->getTableName('core_config_data')
+        $tableName = $this->resourceConnection->getTableName('core_config_data');
+        $configData = $db->fetchAll('SELECT DISTINCT path, value FROM ' . $tableName
             . ' WHERE scope_id = 0');
         foreach ($configData as $config) {
-            $count = $db->fetchOne('SELECT COUNT(*) FROM ' . $db->getTableName('core_config_data')
+            $count = $db->fetchOne('SELECT COUNT(*) FROM ' . $tableName
                 . ' WHERE path = ? AND BINARY value = ?', [$config['path'], $config['value']]);
             if ($count > 1) {
                 $output->writeln('Config path ' . $config['path'] . ' with value ' . $config['value'] . ' has ' . $count
                     . ' values; deleting non-default values');
                 if (!$isDryRun) {
-                    $db->query('DELETE FROM ' . $db->getTableName('core_config_data')
-                        . ' WHERE path = ? AND BINARY value = ? AND scope_id != ?',
-                        [$config['path'], $config['value'], 0]);
+                    $db->query(
+                        'DELETE FROM ' . $tableName . ' WHERE path = ? AND BINARY value = ? AND scope_id != ?',
+                        [$config['path'], $config['value'], 0]
+                    );
                 }
                 $removedConfigValues += ($count - 1);
             }

--- a/Console/Command/RestoreUseDefaultValueCommand.php
+++ b/Console/Command/RestoreUseDefaultValueCommand.php
@@ -75,7 +75,7 @@ class RestoreUseDefaultValueCommand extends Command
 
         foreach ($tables as $table) {
             // Select all non-global values
-            $fullTableName = $db->getTableName('catalog_' . $entity . '_entity_' . $table);
+            $fullTableName = $this->resourceConnection->getTableName('catalog_' . $entity . '_entity_' . $table);
             $rows          = $db->fetchAll('SELECT * FROM ' . $fullTableName . ' WHERE store_id != 0');
 
             foreach ($rows as $row) {


### PR DESCRIPTION
When using a database prefix, the commands in this module do not work. This change allows the same to work. I've tested this on Magento version 2.4.3 with `db/table_prefix` set in `app/etc/env.php`