### PR TITLE
Move null value check outside loop

### DIFF
--- a/Console/Command/RestoreUseDefaultValueCommand.php
+++ b/Console/Command/RestoreUseDefaultValueCommand.php
@@ -107,22 +107,18 @@ class RestoreUseDefaultValueCommand extends Command
                         $counts[$row['attribute_id']]++;
                     }
                 }
+            }
 
-                $nullValues = $db->fetchOne(
-                    'SELECT COUNT(*) FROM ' . $fullTableName
-                    . ' WHERE store_id = ? AND value IS NULL',
-                    [$row['store_id']]
+            $nullValues = $db->fetchOne(
+                'SELECT COUNT(*) FROM ' . $fullTableName . ' WHERE store_id != 0 AND value IS NULL'
+            );
+
+            if (!$isDryRun && $nullValues > 0) {
+                $output->writeln("Deleting " . $nullValues . " NULL value(s) from " . $fullTableName);
+                // Remove all non-global null values
+                $db->query(
+                    'DELETE FROM ' . $fullTableName . ' WHERE store_id != 0 AND value IS NULL'
                 );
-
-                if (!$isDryRun && $nullValues > 0) {
-                    $output->writeln("Deleting " . $nullValues . " NULL value(s) from " . $fullTableName);
-                    // Remove all non-global null values
-                    $db->query(
-                        'DELETE FROM ' . $fullTableName
-                        . ' WHERE store_id = ? AND value IS NULL',
-                        [$row['store_id']]
-                    );
-                }
             }
 
             if (count($counts)) {


### PR DESCRIPTION
When reviewing this module for suitability and quality, I noticed a performance issue in the `eav:attributes:restore-use-default-value` command. When dealing with small databases, this inefficiency does not cost significantly; however, when working with large databases, this is causing significant delay within each loop iteration. This pull request resolves this inefficiency, allowing the command to run more quickly on all database sizes.

I recommend reviewing this with 'ignore white-space' enabled. I have tested this on Magento v2.4.3-p1.