### PR TITLE
Remove data from 'wrong' table

### DIFF
--- a/Console/Command/CleanUpAttributesAndValuesWithoutParentCommand.php
+++ b/Console/Command/CleanUpAttributesAndValuesWithoutParentCommand.php
@@ -76,13 +76,13 @@ class CleanUpAttributesAndValuesWithoutParentCommand extends Command
                 $eavTable         = $this->resourceConnection->getTableName('eav_attribute');
                 $entityValueTable = $this->resourceConnection->getTableName($code . '_entity_' . $type);
                 $query            = "SELECT * FROM $entityValueTable WHERE `attribute_id` NOT IN(SELECT attribute_id"
-                    . " FROM `$eavTable` WHERE entity_type_id = " . $entityType->getEntityTypeId() . ")";
+                    . " FROM `$eavTable` WHERE entity_type_id = " . $entityType->getEntityTypeId() . " AND backend_type = '$type')";
                 $results          = $db->fetchAll($query);
                 $output->writeln("Clean up " . count($results) . " rows in $entityValueTable");
 
                 if (!$isDryRun && count($results) > 0) {
                     $db->query("DELETE FROM $entityValueTable WHERE `attribute_id` NOT IN(SELECT attribute_id"
-                        . " FROM `$eavTable` WHERE entity_type_id = " . $entityType->getEntityTypeId() . ")");
+                        . " FROM `$eavTable` WHERE entity_type_id = " . $entityType->getEntityTypeId() . " AND backend_type = '$type')");
                 }
             }
         }

--- a/Console/Command/CleanUpAttributesAndValuesWithoutParentCommand.php
+++ b/Console/Command/CleanUpAttributesAndValuesWithoutParentCommand.php
@@ -38,7 +38,7 @@ class CleanUpAttributesAndValuesWithoutParentCommand extends Command
     protected function configure()
     {
         $description
-            = 'Remove catalog_eav_attribute and attribute values which are missing parent entry in eav_attribute';
+            = 'Remove orphaned attribute values - those which are missing a parent entry (with the corresponding backend_type) in eav_attribute';
         $this
             ->setName('eav:clean:attributes-and-values-without-parent')
             ->setDescription($description)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Run `bin/magento` in the Magento 2 root and look for the `eav:` commands.
 * `eav:attributes:restore-use-default-value` Check if product attribute admin value and storeview value are the same, so "use default" doesn't work anymore. Delete the storeview values.
 * `eav:attributes:remove-unused` Remove attributes with no values set in products and attributes that are not present in any attribute sets.
 * `eav:media:remove-unused` Remove unused product images.
+* `eav:clean:attributes-and-values-without-parent` Remove orphaned attribute values - those which are missing a parent entry (with the corresponding `backend_type`) in `eav_attribute`.
 
 ## Dry run
 Use `--dry-run` to check result without modifying data.
@@ -22,7 +23,6 @@ Installation with composer:
 ```bash
 composer require magento-hackathon/module-eavcleaner-m2
 ```
-
 
 ### Contributors
 - Nikita Zhavoronkova


### PR DESCRIPTION
When the `backend_type` of an attribute changes (eg, from `varchar` to `text`), Magento will not clean up / migrate the data from the old table automatically. Extensions should do this as part of changing the `backend_type`, but not all extensions follow best practices.
This pull request updates the SQL used to identify orphaned data to also detect data in the 'wrong' table.