### PR TITLE
Replace use of fetchAll() for database queries

### DIFF
--- a/Console/Command/CleanUpAttributesAndValuesWithoutParentCommand.php
+++ b/Console/Command/CleanUpAttributesAndValuesWithoutParentCommand.php
@@ -85,12 +85,12 @@ class CleanUpAttributesAndValuesWithoutParentCommand extends Command
             foreach ($types as $type) {
                 $eavTable         = $this->resourceConnection->getTableName('eav_attribute');
                 $entityValueTable = $this->resourceConnection->getTableName($code . '_entity_' . $type);
-                $query            = "SELECT * FROM $entityValueTable WHERE `attribute_id` NOT IN(SELECT attribute_id"
+                $query = "SELECT COUNT(*) FROM $entityValueTable WHERE `attribute_id` NOT IN(SELECT attribute_id"
                     . " FROM `$eavTable` WHERE entity_type_id = " . $entityType->getEntityTypeId() . " AND backend_type = '$type')";
-                $results          = $db->fetchAll($query);
-                $output->writeln("Clean up " . count($results) . " rows in $entityValueTable");
+                $count = (int) $db->fetchOne($query);
+                $output->writeln("Clean up $count rows in $entityValueTable");
 
-                if (!$isDryRun && count($results) > 0) {
+                if (!$isDryRun && $count > 0) {
                     $db->query("DELETE FROM $entityValueTable WHERE `attribute_id` NOT IN(SELECT attribute_id"
                         . " FROM `$eavTable` WHERE entity_type_id = " . $entityType->getEntityTypeId() . " AND backend_type = '$type')");
                 }

--- a/Console/Command/RestoreUseDefaultValueCommand.php
+++ b/Console/Command/RestoreUseDefaultValueCommand.php
@@ -92,7 +92,9 @@ class RestoreUseDefaultValueCommand extends Command
         foreach ($tables as $table) {
             // Select all non-global values
             $fullTableName = $this->resourceConnection->getTableName('catalog_' . $entity . '_entity_' . $table);
-            $query = $dbRead->query("SELECT * FROM $fullTableName WHERE store_id != 0");
+
+            // NULL values are handled separately
+            $query = $dbRead->query("SELECT * FROM $fullTableName WHERE store_id != 0 AND value IS NOT NULL");
 
             $iterator = $this->iteratorFactory->create();
             $iterator->walk($query, [function (array $result) use ($column, &$counts, $dbRead, $dbWrite, $fullTableName, $isDryRun, $output): void {

--- a/Console/Command/RestoreUseDefaultValueCommand.php
+++ b/Console/Command/RestoreUseDefaultValueCommand.php
@@ -4,6 +4,7 @@ namespace Hackathon\EAVCleaner\Console\Command;
 
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Model\ResourceModel\IteratorFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -12,6 +13,9 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class RestoreUseDefaultValueCommand extends Command
 {
+    /** @var IteratorFactory */
+    protected $iteratorFactory;
+
     /**
      * @var ProductMetaDataInterface
      */
@@ -23,11 +27,14 @@ class RestoreUseDefaultValueCommand extends Command
     private $resourceConnection;
 
     public function __construct(
+        IteratorFactory $iteratorFactory,
         ProductMetaDataInterface $productMetaData,
         ResourceConnection $resourceConnection,
         string $name = null
     ) {
         parent::__construct($name);
+
+        $this->iteratorFactory = $iteratorFactory;
         $this->productMetaData    = $productMetaData;
         $this->resourceConnection = $resourceConnection;
     }
@@ -58,7 +65,7 @@ class RestoreUseDefaultValueCommand extends Command
         if (!in_array($entity, ['product', 'category'])) {
             $output->writeln('Please specify the entity with --entity. Possible options are product or category');
 
-            return 1;
+            return 1; // error.
         }
 
         if (!$isDryRun && !$isForce) {
@@ -76,7 +83,8 @@ class RestoreUseDefaultValueCommand extends Command
             }
         }
 
-        $db     = $this->resourceConnection->getConnection();
+        $dbRead = $this->resourceConnection->getConnection('core_read');
+        $dbWrite = $this->resourceConnection->getConnection('core_write');
         $counts = [];
         $tables = ['varchar', 'int', 'decimal', 'text', 'datetime'];
         $column = $this->productMetaData->getEdition() === 'Enterprise' ? 'row_id' : 'entity_id';
@@ -84,49 +92,53 @@ class RestoreUseDefaultValueCommand extends Command
         foreach ($tables as $table) {
             // Select all non-global values
             $fullTableName = $this->resourceConnection->getTableName('catalog_' . $entity . '_entity_' . $table);
-            $rows          = $db->fetchAll('SELECT * FROM ' . $fullTableName . ' WHERE store_id != 0');
+            $query = $dbRead->query("SELECT * FROM $fullTableName WHERE store_id != 0");
 
-            foreach ($rows as $row) {
+            $iterator = $this->iteratorFactory->create();
+            $iterator->walk($query, [function (array $result) use ($column, &$counts, $dbRead, $dbWrite, $fullTableName, $isDryRun, $output): void {
+                $row = $result['row'];
+
                 // Select the global value if it's the same as the non-global value
-                $results = $db->fetchAll(
+                $query = $dbRead->query(
                     'SELECT * FROM ' . $fullTableName
                     . ' WHERE attribute_id = ? AND store_id = ? AND ' . $column . ' = ? AND BINARY value = ?',
                     [$row['attribute_id'], 0, $row[$column], $row['value']]
                 );
 
-                if (count($results) > 0) {
-                    foreach ($results as $result) {
-                        if (!$isDryRun) {
-                            // Remove the non-global value
-                            $db->query(
-                                'DELETE FROM ' . $fullTableName . ' WHERE value_id = ?',
-                                $row['value_id']
-                            );
-                        }
+                $iterator = $this->iteratorFactory->create();
+                $iterator->walk($query, [function (array $result) use (&$counts, $dbWrite, $fullTableName, $isDryRun, $output, $row): void {
+                    $result = $result['row'];
 
-                        $output->writeln(
-                            'Deleting value ' . $row['value_id'] . ' "' . $row['value'] . '" in favor of '
-                            . $result['value_id']
-                            . ' for attribute ' . $row['attribute_id'] . ' in table ' . $fullTableName
+                    if (!$isDryRun) {
+                        // Remove the non-global value
+                        $dbWrite->query(
+                            'DELETE FROM ' . $fullTableName . ' WHERE value_id = ?',
+                            $row['value_id']
                         );
-
-                        if (!isset($counts[$row['attribute_id']])) {
-                            $counts[$row['attribute_id']] = 0;
-                        }
-
-                        $counts[$row['attribute_id']]++;
                     }
-                }
-            }
 
-            $nullValues = $db->fetchOne(
+                    $output->writeln(
+                        'Deleting value ' . $row['value_id'] . ' "' . $row['value'] . '" in favor of '
+                        . $result['value_id']
+                        . ' for attribute ' . $row['attribute_id'] . ' in table ' . $fullTableName
+                    );
+
+                    if (!isset($counts[$row['attribute_id']])) {
+                        $counts[$row['attribute_id']] = 0;
+                    }
+
+                    $counts[$row['attribute_id']]++;
+                }]);
+            }]);
+
+            $nullCount = (int) $dbRead->fetchOne(
                 'SELECT COUNT(*) FROM ' . $fullTableName . ' WHERE store_id != 0 AND value IS NULL'
             );
 
-            if (!$isDryRun && $nullValues > 0) {
-                $output->writeln("Deleting " . $nullValues . " NULL value(s) from " . $fullTableName);
+            if (!$isDryRun && $nullCount > 0) {
+                $output->writeln("Deleting $nullCount NULL value(s) from $fullTableName");
                 // Remove all non-global null values
-                $db->query(
+                $dbWrite->query(
                     'DELETE FROM ' . $fullTableName . ' WHERE store_id != 0 AND value IS NULL'
                 );
             }


### PR DESCRIPTION
When running `bin/magento eav:attributes:restore-use-default-value` on a website with a large catalogue, PHP ran out of memory. This is because the command attempted to load all values into memory, however as only one row is processed at a time, replacing this with the resource iterator makes sense. With the changes in this pull request I am now able to use all commands on this website.