### PR TITLE
Consider the relation table media to entity when removing unused media images

### DIFF
--- a/Console/Command/RemoveUnusedMediaCommand.php
+++ b/Console/Command/RemoveUnusedMediaCommand.php
@@ -17,11 +17,8 @@ class RemoveUnusedMediaCommand extends Command
 {
     private const OPTION_DRY_RUN = 'dry-run';
     private const OPTION_INCLUDING_CACHE = 'including-cache';
-
     private const OPTION_ONLY_CACHE = 'only-cache';
-
     private const OPTION_INCLUDING_RELATION_ENTITY = 'including-relation';
-
     private const OPTION_FORCE = 'force';
     private const COMMAND_NAME_EAV_MEDIA_REMOVE_UNUSED = 'eav:media:remove-unused';
 
@@ -79,7 +76,6 @@ class RemoveUnusedMediaCommand extends Command
         }
 
         $imageDir = $this->getImageDir();
-
         $connection = $this->resourceConnection->getConnection('core_read');
         $mediaGalleryTable = $this->resourceConnection->getTableName('catalog_product_entity_media_gallery');
 
@@ -87,13 +83,11 @@ class RemoveUnusedMediaCommand extends Command
 
         $imagesToKeep = $connection->fetchCol('SELECT value FROM ' . $mediaGalleryTable);
 
-        // begin new code
         if ($deleteNotInRelation) {
             $mediaGalleryToEntityTable = $this->resourceConnection->getTableName('catalog_product_entity_media_gallery_value_to_entity');
             $sql='SELECT value FROM ' . $mediaGalleryTable. ' where value_id IN (SELECT value_id from '.$mediaGalleryToEntityTable.')';
             $imagesToKeep = $connection->fetchCol($sql);
         }
-        // end
 
         foreach (new RecursiveIteratorIterator($directoryIterator) as $file) {
             // Directory guard
@@ -181,28 +175,24 @@ class RemoveUnusedMediaCommand extends Command
     {
         $this->setName(self::COMMAND_NAME_EAV_MEDIA_REMOVE_UNUSED);
         $this->setDescription('Remove unused product images');
-
         $this->addOption(
             self::OPTION_INCLUDING_CACHE,
             'c',
             null,
             'Also clear the ./cache/* entries for the corresponding images'
         );
-
         $this->addOption(
             self::OPTION_ONLY_CACHE,
             'k',
             null,
             'Clear only the ./cache/* entries for the corresponding images nad not the corresponding images'
         );
-
         $this->addOption(
             self::OPTION_INCLUDING_RELATION_ENTITY,
             'r',
             null,
             'Also clear the media not in relation table "catalog_product_entity_media_gallery_value_to_entity"'
         );
-
         $this->addOption(
             self::OPTION_DRY_RUN,
             'd',

--- a/Console/Command/RemoveUnusedMediaCommand.php
+++ b/Console/Command/RemoveUnusedMediaCommand.php
@@ -185,7 +185,7 @@ class RemoveUnusedMediaCommand extends Command
             self::OPTION_ONLY_CACHE,
             'k',
             null,
-            'Clear only the ./cache/* entries for the corresponding images nad not the corresponding images'
+            'Clear only the ./cache/* entries for the corresponding images, but not the corresponding images'
         );
         $this->addOption(
             self::OPTION_INCLUDING_RELATION_ENTITY,

--- a/Console/Command/RemoveUnusedMediaCommand.php
+++ b/Console/Command/RemoveUnusedMediaCommand.php
@@ -17,6 +17,11 @@ class RemoveUnusedMediaCommand extends Command
 {
     private const OPTION_DRY_RUN = 'dry-run';
     private const OPTION_INCLUDING_CACHE = 'including-cache';
+
+    private const OPTION_ONLY_CACHE = 'only-cache';
+
+    private const OPTION_INCLUDING_RELATION_ENTITY = 'including-relation';
+
     private const OPTION_FORCE = 'force';
     private const COMMAND_NAME_EAV_MEDIA_REMOVE_UNUSED = 'eav:media:remove-unused';
 
@@ -44,6 +49,11 @@ class RemoveUnusedMediaCommand extends Command
         $isForce = $input->getOption(self::OPTION_FORCE);
         $isDryRun = $input->getOption(self::OPTION_DRY_RUN);
         $deleteCacheAsWell = $input->getOption(self::OPTION_INCLUDING_CACHE);
+        $deleteOnlyCache = $input->getOption(self::OPTION_ONLY_CACHE);
+        if ($deleteOnlyCache) {
+            $deleteCacheAsWell=true;
+        }
+        $deleteNotInRelation = $input->getOption(self::OPTION_INCLUDING_RELATION_ENTITY);
 
         if (!$isDryRun && !$isForce) {
             if (!$input->isInteractive()) {
@@ -69,12 +79,21 @@ class RemoveUnusedMediaCommand extends Command
         }
 
         $imageDir = $this->getImageDir();
+
         $connection = $this->resourceConnection->getConnection('core_read');
         $mediaGalleryTable = $this->resourceConnection->getTableName('catalog_product_entity_media_gallery');
 
         $directoryIterator = new RecursiveDirectoryIterator($imageDir);
 
         $imagesToKeep = $connection->fetchCol('SELECT value FROM ' . $mediaGalleryTable);
+
+        // begin new code
+        if ($deleteNotInRelation) {
+            $mediaGalleryToEntityTable = $this->resourceConnection->getTableName('catalog_product_entity_media_gallery_value_to_entity');
+            $sql='SELECT value FROM ' . $mediaGalleryTable. ' where value_id IN (SELECT value_id from '.$mediaGalleryToEntityTable.')';
+            $imagesToKeep = $connection->fetchCol($sql);
+        }
+        // end
 
         foreach (new RecursiveIteratorIterator($directoryIterator) as $file) {
             // Directory guard
@@ -84,6 +103,11 @@ class RemoveUnusedMediaCommand extends Command
 
             // Cached guard
             if ($this->isInCachePath($file) && !$deleteCacheAsWell) {
+                continue;
+            }
+
+            // Original image guard if option --only-cache
+            if (!$this->isInCachePath($file) && $deleteOnlyCache) {
                 continue;
             }
 
@@ -164,6 +188,21 @@ class RemoveUnusedMediaCommand extends Command
             null,
             'Also clear the ./cache/* entries for the corresponding images'
         );
+
+        $this->addOption(
+            self::OPTION_ONLY_CACHE,
+            'k',
+            null,
+            'Clear only the ./cache/* entries for the corresponding images nad not the corresponding images'
+        );
+
+        $this->addOption(
+            self::OPTION_INCLUDING_RELATION_ENTITY,
+            'r',
+            null,
+            'Also clear the media not in relation table "catalog_product_entity_media_gallery_value_to_entity"'
+        );
+
         $this->addOption(
             self::OPTION_DRY_RUN,
             'd',


### PR DESCRIPTION
The table "catalog_product_entity_media_gallery_value_to_entity" is the relation between a gallery entry and a product. Images not in this relation could be deleted.  I added a new option that consider this relation. 
I also added a new option to delete the cache images only.  