### PR TITLE
Inject concrete DriverInterface implementation

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -11,4 +11,9 @@
             </argument>
         </arguments>
     </type>
+    <type name="Hackathon\EAVCleaner\Console\Command\RemoveUnusedMediaCommand">
+        <arguments>
+            <argument name="driver" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
When running `bin/magento setup:upgrade` with the latest version of this module (`1.6.0`), the following error occurs:

```
╰─ ddev magento s:up
Cannot instantiate interface Magento\Framework\Filesystem\DriverInterface#0 /var/www/html/vendor/magento/framework/ObjectManager/ObjectManager.php(70): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->create('Magento\\Framewo...')
#1 /var/www/html/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(170): Magento\Framework\ObjectManager\ObjectManager->get('Magento\\Framewo...')
#2 /var/www/html/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(276): Magento\Framework\ObjectManager\Factory\AbstractFactory->resolveArgument(Array, 'Magento\\Framewo...', NULL, 'driver', 'Hackathon\\EAVCl...')
#3 /var/www/html/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(239): Magento\Framework\ObjectManager\Factory\AbstractFactory->getResolvedArgument('Hackathon\\EAVCl...', Array, Array)
#4 /var/www/html/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(34): Magento\Framework\ObjectManager\Factory\AbstractFactory->resolveArgumentsInRuntime('Hackathon\\EAVCl...', Array, Array)
#5 /var/www/html/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(59): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->_resolveArguments('Hackathon\\EAVCl...', Array, Array)
#6 /var/www/html/vendor/magento/framework/ObjectManager/ObjectManager.php(70): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->create('Hackathon\\EAVCl...')
#7 /var/www/html/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(206): Magento\Framework\ObjectManager\ObjectManager->get('Hackathon\\EAVCl...')
#8 /var/www/html/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(182): Magento\Framework\ObjectManager\Factory\AbstractFactory->parseArray(Array)
#9 /var/www/html/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(276): Magento\Framework\ObjectManager\Factory\AbstractFactory->resolveArgument(Array, NULL, Array, 'commands', 'Magento\\Framewo...')
#10 /var/www/html/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(239): Magento\Framework\ObjectManager\Factory\AbstractFactory->getResolvedArgument('Magento\\Framewo...', Array, Array)
#11 /var/www/html/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(34): Magento\Framework\ObjectManager\Factory\AbstractFactory->resolveArgumentsInRuntime('Magento\\Framewo...', Array, Array)
#12 /var/www/html/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(59): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->_resolveArguments('Magento\\Framewo...', Array, Array)
#13 /var/www/html/vendor/magento/framework/ObjectManager/ObjectManager.php(56): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->create('Magento\\Framewo...', Array)
#14 /var/www/html/vendor/magento/framework/Console/Cli.php(154): Magento\Framework\ObjectManager\ObjectManager->create('Magento\\Framewo...')
#15 /var/www/html/vendor/magento/framework/Console/Cli.php(135): Magento\Framework\Console\Cli->getApplicationCommands()
#16 /var/www/html/vendor/symfony/console/Application.php(1297): Magento\Framework\Console\Cli->getDefaultCommands()
#17 /var/www/html/vendor/symfony/console/Application.php(673): Symfony\Component\Console\Application->init()
#18 /var/www/html/vendor/symfony/console/Application.php(259): Symfony\Component\Console\Application->find('s:up')
#19 /var/www/html/vendor/magento/framework/Console/Cli.php(116): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#20 /var/www/html/vendor/symfony/console/Application.php(171): Magento\Framework\Console\Cli->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#21 /var/www/html/bin/magento(23): Symfony\Component\Console\Application->run()
#22 {main}
```

Ref: https://github.com/magento-hackathon/module-eavcleaner-m2/pull/28/files#diff-e596fa45b81c55fd172cc0b35deb307d4a5cb7c002e6766bd3b2201698c30b62R59

The interface `Magento\Framework\Filesystem\DriverInterface` has no `<preference>` declaration in Magento, so the Object Manager can't find a concrete class to inject. As such, we need to provide one via `di.xml`.