### PR TITLE
Major performance improvement for shops with many images and fast volumes

### DIFF
--- a/Console/Command/RemoveUnusedMediaCommand.php
+++ b/Console/Command/RemoveUnusedMediaCommand.php
@@ -165,6 +165,8 @@ class RemoveUnusedMediaCommand extends Command
             $imagesToKeep = $connection->fetchCol($select);
         }
 
+        $imagesToKeep = array_flip($imagesToKeep);
+
         foreach (new RecursiveIteratorIterator($directoryIterator) as $file) {
             // Directory guard
             if ($this->driver->isDirectory($file)) {
@@ -188,7 +190,7 @@ class RemoveUnusedMediaCommand extends Command
             }
 
             $filePathWithoutCacheDir = preg_replace('#/cache_*/[a-z0-9]+(/[a-z0-9]/[a-z0-9]/.+?)#i', '$1', $filePath);
-            if (in_array($filePathWithoutCacheDir, $imagesToKeep, true)) {
+            if (key_exists($filePathWithoutCacheDir, $imagesToKeep)) {
                 continue;
             }
 
@@ -197,7 +199,7 @@ class RemoveUnusedMediaCommand extends Command
                 continue;
             }
 
-            if (in_array($filePath, $imagesToKeep, true)) {
+            if (key_exists($filePath, $imagesToKeep)) {
                 continue;
             }
 

--- a/Console/Command/RemoveUnusedMediaCommand.php
+++ b/Console/Command/RemoveUnusedMediaCommand.php
@@ -190,7 +190,7 @@ class RemoveUnusedMediaCommand extends Command
             }
 
             $filePathWithoutCacheDir = preg_replace('#/cache_*/[a-z0-9]+(/[a-z0-9]/[a-z0-9]/.+?)#i', '$1', $filePath);
-            if (key_exists($filePathWithoutCacheDir, $imagesToKeep)) {
+            if (array_key_exists($filePathWithoutCacheDir, $imagesToKeep)) {
                 continue;
             }
 
@@ -199,7 +199,7 @@ class RemoveUnusedMediaCommand extends Command
                 continue;
             }
 
-            if (key_exists($filePath, $imagesToKeep)) {
+            if (array_key_exists($filePath, $imagesToKeep)) {
                 continue;
             }
 


### PR DESCRIPTION
I tried out the extension and --dry-run for image clean-up felt awfully slow.

I found that `$imagesToKeep` gets huge very quickly and contains the same values many times (35+ times).
In conjunction with the current look-up implementation, this quickly becomes very time-consuming.

The following optimization improves _dry-run_ performance on my developer machine (customer shop, ~20000 products with images)
- from 20 files / second
- to 90000+ files / second

Overall performance depends on the block storage of course, but with this improvement at least php shouldn't become the bottle-neck anymore.